### PR TITLE
Modularize bulk loader

### DIFF
--- a/ncbi/common.py
+++ b/ncbi/common.py
@@ -1,0 +1,132 @@
+"""
+Common code for dealing with NCBI taxonomy files.
+"""
+
+import re
+import unicodedata
+from collections import defaultdict
+
+_CANONICAL_IGNORE_SET = {'et','al','and','or','the','a'}
+_SEP = r'\s\|\s?'
+_SCI_NAME = 'scientific name'
+
+
+# assumes there's at least one non-whitespace char in string
+# this is not ncbi specific, move elsewhere
+def canonicalize(string, ignore_tokens):
+    """
+    Canonicalizes a string by:
+    Lowercasing
+    Unicode normalization
+    Tokenizing
+    Removing non-alphanumeric characters from each end of each token
+    Ignoring any tokens in the ignore_tokens set
+    """
+    # see https://docs.python.org/3/howto/unicode.html#comparing-strings
+    normed = unicodedata.normalize('NFD', unicodedata.normalize('NFD', string).casefold())
+    # maybe include the full string, but normed, in the returned list?
+    tokens = normed.split()
+    # TODO TEST for fencepost errors here
+    ret = []
+    for t in tokens:
+        for start in range(len(t)):
+            if t[start].isalpha() or t[start].isdigit():
+                break
+        for end in range(len(t) - 1, -1, -1):
+            if t[end].isalpha() or t[end].isdigit():
+                break
+        if start <= end:
+            t = t[start: end + 1]
+            if t not in ignore_tokens:
+                ret.append(t)
+    return ret
+
+
+class NCBINodeProvider:
+    """
+    NCBINodeProvider is an iterable that returns a new NCBI taxonomy node as a dict with each
+    iteration.
+    It requires access to the names.dmp and nodes.dmp files from a taxonomy dump.
+    """
+
+    def __init__(self, names_filehandle, nodes_filehandle):
+        """
+        Create the provider.
+        names_filehandle - the opened names.dmp file.
+        nodes_filehandle - the opened nodes.dmp file.
+        """
+        self._names = self._load_names(names_filehandle)
+        self._node_fh = nodes_filehandle
+
+    def _load_names(self, name_file):
+        # Could make this use less memory by parsing one nodes worth of entries at a time, since
+        # both the names and nodes files are sorted by taxid. YAGNI for now
+        name_table = defaultdict(lambda: defaultdict(list))
+        for line in name_file:
+            tax_id, name, _, category = re.split(_SEP, line)[0:4]
+            name_table[tax_id.strip()][category.strip()].append(name.strip())
+
+        return {k: dict(name_table[k]) for k in name_table.keys()}
+
+    def __iter__(self):
+        for line in self._node_fh:
+            record = re.split(_SEP, line)
+            # should really make the ints constants but meh
+            id_, rank, gencode = [record[i].strip() for i in [0,2,6]]
+
+            aliases = []
+            # May need to move names into separate nodes for canonical search purposes
+            for cat in list(self._names[id_].keys()):
+                if cat != _SCI_NAME:
+                    for nam in self._names[id_][cat]:
+                        aliases.append({'category':  cat, 
+                                        'name':      nam, 
+                                        'canonical': canonicalize(nam, _CANONICAL_IGNORE_SET)
+                                        })
+
+            # vertex
+            sci_names = self._names[id_][_SCI_NAME]
+            if len(sci_names) != 1:
+                raise ValueError('Node {} has {} scientific names'.format(id_, len(sci_names)))
+            node = {
+                    'id':                         id_,
+                    'scientific_name':            sci_names[0],
+                    'canonical_scientific_name':  canonicalize(
+                        sci_names[0], _CANONICAL_IGNORE_SET),
+                    'rank':                       rank,
+                    'aliases':                    aliases,
+                    'ncbi_taxon_id':              int(id_),
+                    'gencode':                    gencode,
+                    }
+            
+            yield node
+
+class NCBIEdgeProvider:
+    """
+    NCBIEdgeProvider is an iterable that returns a new NCBI taxonomy edge as a dict where the
+    from key is the child ID and the to key the parent ID with each
+    iteration.
+    It requires access to the nodes.dmp files from a taxonomy dump.
+    """
+
+    def __init__(self, nodes_filehandle):
+        """
+        Create the provider.
+        nodes_filehandle - the opened nodes.dmp file.
+        """
+        self._node_fh = nodes_filehandle
+
+    def __iter__(self):
+        for line in self._node_fh:
+            record = re.split(_SEP, line)
+            # should really make the ints constants but meh
+            id_, parent = [record[i].strip() for i in [0,1]]
+
+            if id_ == parent:
+                continue  # no self edges
+            
+            edge = {
+                'from': id_,
+                'to': parent
+            }
+            yield edge

--- a/ncbi/load/ncbi_taxa_loader_bulk.py
+++ b/ncbi/load/ncbi_taxa_loader_bulk.py
@@ -7,7 +7,7 @@
 # It should only be used for an initial load into the DB; delta loads for subsequent tax dumps
 # should be handled by the delta load script.
 
-# The script requires three inputs:
+# The script requires four inputs:
 # 1) The directory containing the unzipped taxa dump
 # 2) The name of the ADB collection in which the taxa nodes will be loaded
 #    (this is used to create the _from and _to fields in the edges)
@@ -16,12 +16,11 @@
 # 4) The time stamp for the load in unix epoch milliseconds - all nodes and edges will be marked
 #    with this timestamp as the creation date.
 
-# The script creates three JSON files for uploading into Arango:   
+# The script creates two JSON files for uploading into Arango:   
 #       ncbi_taxa_nodes.json    - the taxa vertexes
 #       ncbi_taxa_edges.json    - the taxa edges
 
 # TODO TESTS
-# TODO quite a bit of this code can be shared with the delta loader
 
 import argparse
 import json
@@ -32,115 +31,60 @@ import unicodedata
 from collections import defaultdict
 from pprint import pprint
 
+# probably want to namespace this behind biokbase
+from ncbi.common import NCBINodeProvider
+from ncbi.common import NCBIEdgeProvider
+
 NODES_OUT_FILE = 'ncbi_taxa_nodes.json'
 EDGES_OUT_FILE = 'ncbi_taxa_edges.json'
 
 NAMES_IN_FILE = 'names.dmp'
 NODES_IN_FILE = 'nodes.dmp'
 
-SCI_NAME = 'scientific name'
-
-CANONICAL_IGNORE_SET = {'et','al','and','or','the','a'}
-
-SEP = r'\s\|\s?'
-
 # see https://www.arangodb.com/2018/07/time-traveling-with-graph-databases/
 # in unix epoch ms this is 2255/6/5
 MAX_ADB_INTEGER = 2**53 - 1
 
-def load_names(name_file):
-    # Could make this use less memory by parsing one nodes worth of entries at a time, since
-    # both the names and nodes files are sorted by taxid. YAGNI for now
-    name_table = defaultdict(lambda: defaultdict(list))
-    with open(name_file) as nf:
-        for line in nf:
-            tax_id, name, _, category = re.split(SEP, line)[0:4]
-            name_table[tax_id.strip()][category.strip()].append(name.strip())
-
-    return {k: dict(name_table[k]) for k in name_table.keys()}
-
-
-# assumes there's at least one non-whitespace char in string
-def canonicalize(string, ignore_tokens):
-    # see https://docs.python.org/3/howto/unicode.html#comparing-strings
-    normed = unicodedata.normalize('NFD', unicodedata.normalize('NFD', string).casefold())
-    # maybe include the full string, but normed, in the returned list?
-    tokens = normed.split()
-    # TODO TEST for fencepost errors here
-    ret = []
-    for t in tokens:
-        for start in range(len(t)):
-            if t[start].isalpha() or t[start].isdigit():
-                break
-        for end in range(len(t) - 1, -1, -1):
-            if t[end].isalpha() or t[end].isdigit():
-                break
-        if start <= end:
-            t = t[start: end + 1]
-            if t not in ignore_tokens:
-                ret.append(t)
-    return ret
-
 def process_nodes(
         nodes_in,
-        name_table,
+        names_in,
+        load_version,
+        timestamp,
+        nodes_out):
+    with open(nodes_in) as infile, open(names_in) as namesfile, open(nodes_out, 'w') as nodef:
+        nodeprov = NCBINodeProvider(namesfile, infile)
+        for n in nodeprov:
+            n.update({
+                '_key':           n['id'] + '_' + load_version,
+                'first_version':  load_version,
+                'last_version':   load_version,
+                'created':        timestamp,
+                'expires':        MAX_ADB_INTEGER
+                })
+            nodef.write(json.dumps(n) + '\n')
+
+def process_edges(
+        nodes_in,
         node_collection,
         load_version,
         timestamp,
-        nodes_out,
-        edges_out
+        edges_out,
         ):
-    with open(nodes_in) as infile, open(nodes_out, 'w') as nodef, open(edges_out, 'w') as edgef:
-        for line in infile:
-            record = re.split(SEP, line)
-            # should really make the ints constants but meh
-            id_, parent, rank, gencode = [record[i].strip() for i in [0,1,2,6]]
-            node_id = id_ + '_' + load_version
-
-            aliases = []
-            # May need to move names into separate nodes for canonical search purposes
-            for cat in list(name_table[id_].keys()):
-                if cat != SCI_NAME:
-                    for nam in name_table[id_][cat]:
-                        aliases.append({'category':  cat, 
-                                        'name':      nam, 
-                                        'canonical': canonicalize(nam, CANONICAL_IGNORE_SET)
-                                        })
-
-            # vertex
-            sci_names = name_table[id_][SCI_NAME]
-            if len(sci_names) != 1:
-                raise ValueError('Node {} has {} scientific names'.format(id_, len(sci_names)))
-            nodef.write(json.dumps(
-                {'_key':                       node_id,
-                 'id':                         id_,
-                 'scientific_name':            sci_names[0],
-                 'canonical_scientific_name':  canonicalize(sci_names[0], CANONICAL_IGNORE_SET),
-                 'rank':                       rank,
-                 'aliases':                    aliases,
-                 'ncbi_taxon_id':              int(id_),
-                 'gencode':                    gencode,
-                 'first_version':              load_version,
-                 'last_version':               load_version,
-                 'created':                    timestamp,
-                 'expires':                    MAX_ADB_INTEGER
-                 }
-                ) + '\n')
-            
-            # edge
-            if id_ != parent:  # no self edges
-                edgef.write(json.dumps(
-                    {'_from':            node_collection + '/' + node_id,
-                     'from':             node_collection + '/' + id_,
-                     '_to':              node_collection + '/' + parent + '_' + load_version,
-                     'to':               node_collection + '/' + parent,
-                     'first_version':    load_version,
-                     'last_version':     load_version,
-                     'created':          timestamp,
-                     'expires':          MAX_ADB_INTEGER,
-                     'type':             'std'                 # as opposed to merge
-                     }
-                    ) + '\n')
+    with open(nodes_in) as infile, open(edges_out, 'w') as edgef:
+        edgeprov = NCBIEdgeProvider(infile)
+        for e in edgeprov:
+            e.update({
+                '_from':            node_collection + '/' + e['from'] + '_' + load_version,
+                'from':             node_collection + '/' + e['from'],
+                '_to':              node_collection + '/' + e['to'] + '_' + load_version,
+                'to':               node_collection + '/' + e['to'],
+                'first_version':    load_version,
+                'last_version':     load_version,
+                'created':          timestamp,
+                'expires':          MAX_ADB_INTEGER,
+                'type':             'std'                 # as opposed to merge
+            })
+            edgef.write(json.dumps(e) + '\n')
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -168,15 +112,18 @@ def parse_args():
 def main():
     a = parse_args()
 
-    name_table = load_names(os.path.join(a.dir, NAMES_IN_FILE))
-
     process_nodes(
         os.path.join(a.dir, NODES_IN_FILE),
-        name_table,
+        os.path.join(a.dir, NAMES_IN_FILE),
+        a.load_version,
+        a.load_timestamp,
+        os.path.join(a.dir, NODES_OUT_FILE))
+
+    process_edges(
+        os.path.join(a.dir, NODES_IN_FILE),
         a.node_collection,
         a.load_version,
         a.load_timestamp,
-        os.path.join(a.dir, NODES_OUT_FILE),
         os.path.join(a.dir, EDGES_OUT_FILE))
 
 if __name__  == '__main__':


### PR DESCRIPTION
Separates the file parsers from the transform code, allowing swapping in of
other file parsers. Also allows the parsers to be reused elsewhere.