### PR TITLE
Refactor bulk loader & update for multiple edges

### DIFF
--- a/relation_engine/ncbi/load/ncbi_taxa_loader_bulk.py
+++ b/relation_engine/ncbi/load/ncbi_taxa_loader_bulk.py
@@ -45,46 +45,61 @@ NODES_IN_FILE = 'nodes.dmp'
 # in unix epoch ms this is 2255/6/5
 MAX_ADB_INTEGER = 2**53 - 1
 
-def process_nodes(
-        nodes_in,
-        names_in,
-        load_version,
-        timestamp,
-        nodes_out):
-    with open(nodes_in) as infile, open(names_in) as namesfile, open(nodes_out, 'w') as nodef:
-        nodeprov = NCBINodeProvider(namesfile, infile)
-        for n in nodeprov:
-            n.update({
-                '_key':           n['id'] + '_' + load_version,
-                'first_version':  load_version,
-                'last_version':   load_version,
-                'created':        timestamp,
-                'expires':        MAX_ADB_INTEGER
-                })
-            nodef.write(json.dumps(n) + '\n')
+def process_nodes(nodeprov, load_version, timestamp, nodes_out):
+    """
+    Process graph nodes from a provider into a JSON load file for a batch time travelling load.
 
-def process_edges(
-        nodes_in,
-        node_collection,
-        load_version,
-        timestamp,
-        edges_out,
-        ):
-    with open(nodes_in) as infile, open(edges_out, 'w') as edgef:
-        edgeprov = NCBIEdgeProvider(infile)
-        for e in edgeprov:
-            e.update({
-                '_from':            node_collection + '/' + e['from'] + '_' + load_version,
-                'from':             node_collection + '/' + e['from'],
-                '_to':              node_collection + '/' + e['to'] + '_' + load_version,
-                'to':               node_collection + '/' + e['to'],
-                'first_version':    load_version,
-                'last_version':     load_version,
-                'created':          timestamp,
-                'expires':          MAX_ADB_INTEGER,
-                'type':             'std'                 # as opposed to merge
+    This function is only suitable for the initial load in the time travelling database.
+    Further loads must use a delta load algorithm.
+
+    Nodes are expected to have an 'id' field containing the node's unique ID.
+
+    nodeprov - the node provider. This is an iterable that returns nodes represented as dicts.
+    load_version - the version of the load in which the nodes appear.
+    timestamp - the timestamp at which the nodes will begin to exist.
+    nodes_out - a handle to the file where the nodes will be written.
+    """
+    for n in nodeprov:
+        n.update({
+            '_key':           n['id'] + '_' + load_version,
+            'first_version':  load_version,
+            'last_version':   load_version,
+            'created':        timestamp,
+            'expires':        MAX_ADB_INTEGER
             })
-            edgef.write(json.dumps(e) + '\n')
+        nodes_out.write(json.dumps(n) + '\n')
+
+def process_edges(edgeprov, node_collection, load_version, timestamp, edges_out):
+    """
+    Process graph edges from a provider into a JSON load file for a batch time travelling load.
+
+    This function is only suitable for the initial load in the time travelling database.
+    Further loads must use a delta load algorithm.
+
+    Edges are expected to have the following fields:
+    id - the edge's unique ID.
+    from - the unique ID of the vertex from where the edge originates.
+    to - the unique ID of the vertex where the edge terminates.
+
+    edgeprov - the edge provider. This is an iterable that returns edges represented as dicts.
+    node_collection - the name of the collection in which the nodes associated with the edges
+      reside. This is used to generate the _from and _to fields.
+    load_version - the version of the load in which the edges appear.
+    timestamp - the timestamp at which the edges will begin to exist.
+    edges_out - a handle to the file where the edges will be written.
+    
+    """
+    for e in edgeprov:
+        e.update({
+            '_key':             e['id'] + '_' + load_version,
+            '_from':            node_collection + '/' + e['from'] + '_' + load_version,
+            '_to':              node_collection + '/' + e['to'] + '_' + load_version,
+            'first_version':    load_version,
+            'last_version':     load_version,
+            'created':          timestamp,
+            'expires':          MAX_ADB_INTEGER,
+        })
+        edges_out.write(json.dumps(e) + '\n')
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -111,20 +126,19 @@ def parse_args():
 
 def main():
     a = parse_args()
+    nodes = os.path.join(a.dir, NODES_IN_FILE)
+    names = os.path.join(a.dir, NAMES_IN_FILE)
 
-    process_nodes(
-        os.path.join(a.dir, NODES_IN_FILE),
-        os.path.join(a.dir, NAMES_IN_FILE),
-        a.load_version,
-        a.load_timestamp,
-        os.path.join(a.dir, NODES_OUT_FILE))
+    nodes_out = os.path.join(a.dir, NODES_OUT_FILE)
+    edges_out = os.path.join(a.dir, EDGES_OUT_FILE)
 
-    process_edges(
-        os.path.join(a.dir, NODES_IN_FILE),
-        a.node_collection,
-        a.load_version,
-        a.load_timestamp,
-        os.path.join(a.dir, EDGES_OUT_FILE))
+    with open(nodes) as infile, open(names) as namesfile, open(nodes_out, 'w') as node_out:
+        nodeprov = NCBINodeProvider(namesfile, infile)
+        process_nodes(nodeprov, a.load_version, a.load_timestamp, node_out)
+
+    with open(nodes) as infile, open(edges_out, 'w') as edgef:
+        edgeprov = NCBIEdgeProvider(infile)
+        process_edges(edgeprov, a.node_collection, a.load_version, a.load_timestamp, edgef)
 
 if __name__  == '__main__':
     main()

--- a/relation_engine/ncbi/taxa_parsers.py
+++ b/relation_engine/ncbi/taxa_parsers.py
@@ -95,6 +95,7 @@ class NCBIEdgeProvider:
                 continue  # no self edges
             
             edge = {
+                'id': id_ + '_' + parent,
                 'from': id_,
                 'to': parent
             }


### PR DESCRIPTION
- the ncbi edge parser now generates a unique id per edge.
- the ncbi loader no longer adds an edge type as we expect to put merge edges in
   different collections.
- The ncbi bulk loader has been refactored  to allow moving the node and edge
  processing code into a common area (next).