### PR TITLE
expire_edge, set_version_on_edge, verify edge collections

### DIFF
--- a/relation_engine/database/batch_time_travelling_db.py
+++ b/relation_engine/database/batch_time_travelling_db.py
@@ -200,6 +200,19 @@ class ArangoBatchTimeTravellingDB:
 
         col.update({_FLD_KEY: key, _FLD_VER_LST: last_version}, silent=True)
 
+    def set_last_version_on_edge(self, key, last_version, edge_collection=None):
+        """
+        Set the last version field on a edge.
+
+        key - the key of the edge.
+        last_version - the version to set.
+        edge_collection - the collection name to query. If none is provided, the default will
+          be used.
+        """
+        col = self._get_edge_collection(edge_collection)
+
+        col.update({_FLD_KEY: key, _FLD_VER_LST: last_version}, silent=True)
+
     def expire_vertex(self, key, expiration_time, edge_collections=None, vertex_collection=None):
         """
         Sets the expiration time on a vertex and adjacent edges in the given collections.

--- a/relation_engine/database/batch_time_travelling_db.py
+++ b/relation_engine/database/batch_time_travelling_db.py
@@ -8,6 +8,8 @@ more classes and methods can be added as needed.
 
 """
 
+# TODO add a method to verify a collection is an edge collection. _from and _to are silently dropped if not.
+
 from arango.exceptions import CursorEmptyError as _CursorEmptyError
 
 _INTERNAL_ARANGO_FIELDS = ['_rev']
@@ -217,9 +219,9 @@ class ArangoBatchTimeTravellingDB:
         """
         Sets the expiration time on a vertex and adjacent edges in the given collections.
 
-        key - the node key.
+        key - the vertex key.
         expiration_time - the time, in Unix epoch milliseconds, to set as the expiration time
-          on the node and any affected edges.
+          on the vertex and any affected edges.
         edge_collections - a list of names of collections that will be checked for connected
           edges.
         vertex_collection - the collection name to query. If none is provided, the default will
@@ -245,6 +247,20 @@ class ArangoBatchTimeTravellingDB:
                        'timestamp': expiration_time
                        },
             )
+        col.update({_FLD_KEY: key, _FLD_EXPIRED: expiration_time}, silent=True)
+
+    def expire_edge(self, key, expiration_time, edge_collection=None):
+        """
+        Sets the expiration time on an edge in the given collections.
+
+        key - the edge key.
+        expiration_time - the time, in Unix epoch milliseconds, to set as the expiration time
+          on the edge.
+        edge_collection - the collection name to query. If none is provided, the default will
+          be used.
+
+        """
+        col = self._get_edge_collection(edge_collection)
         col.update({_FLD_KEY: key, _FLD_EXPIRED: expiration_time}, silent=True)
 
     # mutates in place!

--- a/relation_engine/database/test/batch_time_travel_test.py
+++ b/relation_engine/database/test/batch_time_travel_test.py
@@ -24,6 +24,24 @@ def arango_db():
 
     sys.delete_database(DB_NAME)
 
+def test_init_fail_bad_edge_collection(arango_db):
+    col_name = 'edge'
+    arango_db.create_collection(col_name)
+
+    try:
+        ArangoBatchTimeTravellingDB(arango_db, default_edge_collection=col_name)
+    except ValueError as e:
+        assert e.args[0] == 'edge is not an edge collection'
+
+def test_expire_edge_bad_edge_collection(arango_db):
+    col_name = 'edge'
+    arango_db.create_collection(col_name)
+
+    try:
+        ArangoBatchTimeTravellingDB(arango_db).expire_edge('k', 3, 'edge')
+    except ValueError as e:
+        assert e.args[0] == 'edge is not an edge collection'
+
 def test_get_vertex(arango_db):
     """
     Tests that getting a vertex returns the correct vertex. In particular checks for OB1 errors.


### PR DESCRIPTION
Adds a method to expire an edge
Adds a method to change the `last_version` field on an edge

Checks that edge collections really are edge collections since inserting edges into node collections silently drops `_to` and `_from`