### PR TITLE
Handle edges in multiple collections

### DIFF
--- a/relation_engine/batchload/delta_load.py
+++ b/relation_engine/batchload/delta_load.py
@@ -20,6 +20,7 @@ def load_graph_delta(
         database,
         timestamp,
         load_version,
+        edge_collections=None,
         merge_information=None):
     """
     Loads a new version of a graph into a graph database, calculating the delta between the graphs
@@ -34,10 +35,16 @@ def load_graph_delta(
     database - a wrapper for the database storing the graph. It must have the same interface as
       batchload.time_travelling_database.ArangoBatchTimeTravellingDB, which is currently the
       only implementation of the interface. The default collections will be used for the vertices
-      and edges.
+      and edges unless edge_collections is provided and the _collection field is specified for
+      edges.
     timestamp - the timestamp, in Unix epoch milliseconds, when the load should be considered as
       active.
     load_version - a unique ID for this load - often the date of the data release.
+    edge_collections - the list of collections that may contain edges (other than merge edges).
+      This list must include any collection names specified by the _collection field in edges,
+      and is used to properly expire edges connected to expired vertices. If the only collection
+      used is the default collection from database.get_default_edge_collection() this argument
+      is not required.
     merge_information - a tuple with two entries:
       1) an iterator that produces edges as dicts that represent merges of vertices.
          An 'id' field is required that uniquely identifies the edge in this load (and any previous
@@ -47,9 +54,15 @@ def load_graph_delta(
       2) The name of the collection where merge edges should be stored.
     """
     db = database
-    edge_collections = [db.get_default_edge_collection()]
+    # TODO spec edge collections in DB constructor & cache objects
+    # TODO check vertex default collection is not none, check edge_collections are edge collections
+    edge_cols = []
+    if db.get_default_edge_collection():
+        edge_cols.append(db.get_default_edge_collection())
     if merge_information:
-        edge_collections.append(merge_information[1])
+        edge_cols.append(merge_information[1])
+    if edge_collections:
+        edge_cols.extend(edge_collections)
     
     # count = 0
     for v in vertex_source:
@@ -58,7 +71,7 @@ def load_graph_delta(
         if not dbv:
             db.save_vertex(v[_ID], load_version, timestamp, v)
         elif not _special_equal(v, dbv):
-            db.expire_vertex(dbv[_KEY], timestamp - 1, edge_collections=edge_collections)
+            db.expire_vertex(dbv[_KEY], timestamp - 1, edge_collections=edge_cols)
             db.save_vertex(v[_ID], load_version, timestamp, v)
         else:
             # mark node as seen in this version
@@ -75,7 +88,7 @@ def load_graph_delta(
             # trying to figure out where to set the edge if nodes are deleted gets complicated,
             # so we don't worry about it for now.
             if dbmerged and dbtarget:
-                db.expire_vertex(dbmerged[_KEY], timestamp - 1, edge_collections=edge_collections)
+                db.expire_vertex(dbmerged[_KEY], timestamp - 1, edge_collections=edge_cols)
                 db.save_edge(m[_ID], dbmerged, dbtarget, load_version, timestamp,
                     edge_collection=merge_information[1])
 
@@ -85,7 +98,12 @@ def load_graph_delta(
     # count = 0
     for e in edge_source:
         # could batch things up here if slow
-        dbe = db.get_edge(e[_ID], timestamp)
+        col = db.get_default_edge_collection()
+        if '_collection' in e:
+            col = e.pop('_collection')
+            if col not in edge_collections:
+                raise ValueError(f'Collection {col} not in provided collection list')
+        dbe = db.get_edge(e[_ID], timestamp, edge_collection=col)
         # The edge exists in the current load so its nodes must exist by now
         # Could cache these, may be fetching the same vertex over and over, but no guarantees
         # the same vertexes are repeated in a reasonable amount of time
@@ -97,18 +115,22 @@ def load_graph_delta(
                     # have been updated this load
                     dbe['_from'] != from_['_id'] or
                     dbe['_to'] != to['_id']):
-                db.expire_edge(dbe[_KEY], timestamp - 1)
-                db.save_edge(e[_ID], from_, to, load_version, timestamp, e)
+                db.expire_edge(dbe[_KEY], timestamp - 1, edge_collection=col)
+                db.save_edge(e[_ID], from_, to, load_version, timestamp, e, edge_collection=col)
             else:
-                db.set_last_version_on_edge(dbe[_KEY], load_version)
+                db.set_last_version_on_edge(dbe[_KEY], load_version, edge_collection=col)
         else:
-            db.save_edge(e[_ID], from_, to, load_version, timestamp, e)
+            db.save_edge(e[_ID], from_, to, load_version, timestamp, e, edge_collection=col)
         # count += 1
         # if count % 1000 == 0:
         #     print(f'edge {count}')
 
     # print('del edges')
-    db.expire_extant_edges_without_last_version(timestamp - 1, load_version)
+    if merge_information:
+        edge_cols.remove(merge_information[1])
+    for col in edge_cols:
+        db.expire_extant_edges_without_last_version(
+            timestamp - 1, load_version, edge_collection=col)
 
 # TODO these fields are shared between here and the database. Should probably put them somewhere in common.
 # same iwth the id and _key fields in the code above


### PR DESCRIPTION
Manually tested for now. Needs a test suite, getting too complicated
to rely on manual testing.

The loader used to run the tests based on this commit:
```
$ git diff relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py
diff --git a/relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py b/relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py
index ca0232b..d7fc219 100644
--- a/relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py
+++ b/relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py
@@ -62,6 +62,11 @@ changes between the prior load and the current load, and retaining the prior loa

     return parser.parse_args()

+def test_edge_wrapper(edge_iter):
+    for e in edge_iter:
+        e['_collection'] = 'ncbi_taxa_edges_' + str(int(e['id']) % 3 + 1)
+        yield e
+
 def main():
     a = parse_args()
     nodes = os.path.join(a.dir, NODES_IN_FILE)
@@ -77,10 +82,11 @@ def main():

     with open(nodes) as in1, open(names) as namesfile, open(nodes) as in2, open(merged) as merge:
         nodeprov = NCBINodeProvider(namesfile, in1)
-        edgeprov = NCBIEdgeProvider(in2)
+        edgeprov = test_edge_wrapper(NCBIEdgeProvider(in2))
         merge = NCBIMergeProvider(merge)

         load_graph_delta(nodeprov, edgeprov, attdb, a.load_timestamp, a.load_version,
+            edge_collections=['ncbi_taxa_edges_1', 'ncbi_taxa_edges_2', 'ncbi_taxa_edges_3'],
             merge_information=(merge, a.merge_edge_collection))

 if __name__  == '__main__':
```