### PR TITLE
Simplify edge expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ a readme file with a name keyed to the script, or embedded in the script.
 * Much of the code is not well tested.
   * The delta loader in particular needs tests.
 * Handling merge edges in the delta loader could be improved.
+  * Merge edges are never expired.
   * Currently only handles merge edges where
     * The merged node was present in the prior load and
     * The target node is present in the current load.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ a readme file with a name keyed to the script, or embedded in the script.
 
 * Much of the code is not well tested.
   * The delta loader in particular needs tests.
+  * Get tests to run in travis
+    * At least when the code is merged into the main RE repos.
 * Handling merge edges in the delta loader could be improved.
   * Merge edges are never expired.
   * Currently only handles merge edges where

--- a/relation_engine/batchload/test/time_travelling_database_test.py
+++ b/relation_engine/batchload/test/time_travelling_database_test.py
@@ -364,8 +364,8 @@ def _setup_expire_vertex(arango_db):
 def test_expire_vertex_single_vertex(arango_db):
     """
     Tests that given a network of nodes and edges where the edges are in 2 collections and the
-    nodes are in a single collection, expiring a single vertex without providing any edge
-    collections to modify updates only that vertex. No other vertices or edges should be modified.
+    nodes are in a single collection, expiring a single vertex updates only that vertex.
+    No other vertices or edges should be modified.
 
     See _setup_set_node_expired for the test setup.
     """
@@ -385,86 +385,6 @@ def test_expire_vertex_single_vertex(arango_db):
     _check_docs(arango_db, edges1, 'edges1')
     _check_docs(arango_db, edges2, 'edges2')
 
-def test_expire_vertex_vert_and_edges_one_collection(arango_db):
-    """
-    Tests that given a network of nodes and edges where the edges are in 2 collections and the
-    nodes are in a single collection, expiring a single vertex where only one of the edge
-    collections is specified to recieve updates results in the correct changes. Only the
-    specfied vertex and the edges connected to that vertex in the specified edge collection should
-    be modified.
-
-    See _setup_set_node_expired for the test setup.
-    """
-
-    _, edges2 = _setup_expire_vertex(arango_db)
-    att = ArangoBatchTimeTravellingDB(arango_db, default_vertex_collection='verts')
-
-    att.expire_vertex('1', 500, ['edges1'])
-
-    ret = att.get_vertex('foo', 200)
-    assert ret == {'_key': '1', '_id': 'verts/1', 'id': 'foo', 'created': 100, 'expired': 500}
-    ret = att.get_vertex('bar', 200)
-    assert ret == {'_key': '2', '_id': 'verts/2', 'id': 'bar', 'created': 100, 'expired': 9000}
-
-    _check_no_fake_changes(arango_db)
-
-    e1_exp = [{'_key': 'e1_1', '_id': 'edges1/e1_1', '_from': 'verts/1', '_to': 'fake/1',
-               'created': 100, 'expired': 500},
-              {'_key': 'e1_2', '_id': 'edges1/e1_2', '_from': 'fake/2', '_to': 'verts/1',
-               'created': 100, 'expired': 500},
-              {'_key': 'e1_3', '_id': 'edges1/e1_3', '_from': 'verts/2', '_to': 'fake/1',
-               'created': 100, 'expired': 9000},
-              {'_key': 'e1_4', '_id': 'edges1/e1_4', '_from': 'fake/2', '_to': 'verts/2',
-               'created': 100, 'expired': 9000}, 
-              ]
-    _check_docs(arango_db, e1_exp, 'edges1')
-
-    _check_docs(arango_db, edges2, 'edges2')
-
-def test_expire_vertex_vert_and_edges_two_collections(arango_db):
-    """
-    Tests that given a network of nodes and edges where the edges are in 2 collections and the
-    nodes are in a single collection, expiring a single vertex where both of the edge
-    collections are specified to recieve updates results in the correct changes. Only the
-    specfied vertex and the edges connected to that vertex in any edge collection should
-    be modified.
-
-    See _setup_set_node_expired for the test setup.
-    """
-
-    _setup_expire_vertex(arango_db)
-    att = ArangoBatchTimeTravellingDB(arango_db, default_vertex_collection='verts')
-
-    att.expire_vertex('1', 500, ['edges1', 'edges2'])
-
-    ret = att.get_vertex('foo', 200)
-    assert ret == {'_key': '1', '_id': 'verts/1', 'id': 'foo', 'created': 100, 'expired': 500}
-    ret = att.get_vertex('bar', 200)
-    assert ret == {'_key': '2', '_id': 'verts/2', 'id': 'bar', 'created': 100, 'expired': 9000}
-
-    _check_no_fake_changes(arango_db)
-
-    e1_exp = [{'_key': 'e1_1', '_id': 'edges1/e1_1', '_from': 'verts/1', '_to': 'fake/1',
-               'created': 100, 'expired': 500},
-              {'_key': 'e1_2', '_id': 'edges1/e1_2', '_from': 'fake/2', '_to': 'verts/1',
-               'created': 100, 'expired': 500},
-              {'_key': 'e1_3', '_id': 'edges1/e1_3', '_from': 'verts/2', '_to': 'fake/1',
-               'created': 100, 'expired': 9000},
-              {'_key': 'e1_4', '_id': 'edges1/e1_4', '_from': 'fake/2', '_to': 'verts/2',
-               'created': 100, 'expired': 9000}, 
-              ]
-    _check_docs(arango_db, e1_exp, 'edges1')
-
-    e2_exp = [{'_key': 'e2_1', '_id': 'edges2/e2_1', '_from': 'verts/1', '_to': 'fake/1',
-               'created': 100, 'expired': 500},
-              {'_key': 'e2_2', '_id': 'edges2/e2_2', '_from': 'fake/2', '_to': 'verts/1',
-               'created': 100, 'expired': 500},
-              {'_key': 'e2_3', '_id': 'edges2/e2_3', '_from': 'verts/2', '_to': 'fake/1',
-               'created': 100, 'expired': 9000},
-              {'_key': 'e2_4', '_id': 'edges2/e2_4', '_from': 'fake/2', '_to': 'verts/2',
-               'created': 100, 'expired': 9000}, 
-              ]
-    _check_docs(arango_db, e2_exp, 'edges2')
 
 def test_expire_edge(arango_db):
     """

--- a/relation_engine/batchload/time_travelling_database.py
+++ b/relation_engine/batchload/time_travelling_database.py
@@ -248,7 +248,7 @@ class ArangoBatchTimeTravellingDB:
 
         col.update({_FLD_KEY: key, _FLD_VER_LST: last_version}, silent=True)
 
-    def expire_vertex(self, key, expiration_time, edge_collections=None, vertex_collection=None):
+    def expire_vertex(self, key, expiration_time, vertex_collection=None):
         """
         Sets the expiration time on a vertex and adjacent edges in the given collections.
 

--- a/relation_engine/batchload/time_travelling_database.py
+++ b/relation_engine/batchload/time_travelling_database.py
@@ -261,25 +261,7 @@ class ArangoBatchTimeTravellingDB:
           be used.
 
         """
-        edge_collections = [] if not edge_collections else edge_collections
         col = self._get_vertex_collection(vertex_collection)
-        # filter out nulls or empty strings and fail early on missing collections
-        edge_names = [self._get_edge_collection(e).name for e in edge_collections if e]
-
-        # you can only do updates on one collection at once
-        for ec in edge_names:
-            self._database.aql.execute(
-            f"""
-            WITH @@vcol FOR v, e IN 1 ANY @start @@ecol
-                UPDATE e WITH {{{_FLD_EXPIRED}: @timestamp}} IN @@ecol
-
-            """,
-            bind_vars={'@vcol': col.name,
-                       '@ecol': ec,
-                       'start': col.name + '/' + key,
-                       'timestamp': expiration_time
-                       },
-            )
         col.update({_FLD_KEY: key, _FLD_EXPIRED: expiration_time}, silent=True)
 
     def expire_edge(self, key, expiration_time, edge_collection=None):


### PR DESCRIPTION
- deal consistently with merge edges. In the current algorithm, if a node
  changes merge edges are expired, but if it's deleted they are not.
  Now merge edges don't expire (although the vertices they're attached to do).
- Don't expire edges attached to nodes at the same time as the nodes for
  changed nodes.  The edges will get expired later in the edge processing
  stage of the algorithm.
- This change means that no traversals are necessary for updates and everything
  can be batched.

Untested. Will write tests for everything when all the bulk changes are complete.