### PR TITLE
Make the vertex collection required in db wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ For a delta loader:
   * Optionally, create a merge edge provider
 * Create an instance of the `ArangoBatchTimeTravellingDB` class. This class is located in
   `relation_engine/batchload/time_travelling_database.py`
-  * The default vertex collection **MUST** be specified. All nodes will be saved to this
-    collection.
-    * The delta loader does not support multiple node collections per graph.
   * If not using the `_collection` field to specify the collection to which an edge belongs for
     all edges, the default edge collection **MUST** be specified. If the `_collection` field
     is missing for an edge, the default edge collection will be used.

--- a/relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py
+++ b/relation_engine/ncbi/taxa/loaders/ncbi_taxa_delta_loader.py
@@ -74,7 +74,7 @@ def main():
     client = ArangoClient(protocol=url.scheme, host=url.hostname, port=url.port)
     attdb = ArangoBatchTimeTravellingDB(
         client.db(a.database, verify=True),
-        default_vertex_collection=a.node_collection,
+        a.node_collection,
         default_edge_collection=a.edge_collection)
 
     with open(nodes) as in1, open(names) as namesfile, open(nodes) as in2, open(merged) as merge:


### PR DESCRIPTION
There's no plans to support more than one vertex collection per graph, so
simplify