### PR TITLE
Remove node collection arg for bulk loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,22 @@ a readme file with a name keyed to the script, or embedded in the script.
 
 ## Time Travelling Loaders
 
-There are two types of loaders supported in this repo, bulk loaders and delta loaders. Bulk loaders
-are used to load the first instance of a graph in to the RE. From then on, delta loaders must be
-used to compare the next graph instance to the prior instance and calculate and apply the
-difference between the two graphs to the RE.
+There are two types of loaders supported in this repo, bulk loaders and delta loaders.
 
-Theoretically, the delta loader could be used to load the first instance of the graph as well,
+### Bulk loaders
+
+Bulk loaders create load files suitable for importing into ArangoDB using `arangoimport` and are
+used to load the first instance of a graph into the RE.
+
+When loading edges collections, the `--from-collection-prefix` and `--to-collection-prefix`
+arguments must be used to specify the name of the node collection(s) to which the edges connect.
+
+### Delta loaders
+
+After the initial load, delta loaders must be used to compare the next graph instance to the
+prior instance and calculate and apply the difference between the two graphs to the RE.
+
+For small graphs the delta loader can be used to load the first instance of the graph as well,
 but since it will perform numerous unnecessary queries against the database to do the graph
 comparison, the bulk loader is typically faster.
 
@@ -44,8 +54,6 @@ fast even with the delta loader.
 Delta loader: `relation_engine/ontologies/obograph/loaders/obograph_delta_loader.py`
 
 ### Requirements
-
-For the the delta loader to operate efficiently:
 
 * ArangoDB must be version 3.5.0+
 * All node and edge collections must have the following persistent indexes

--- a/relation_engine/batchload/load_utils.py
+++ b/relation_engine/batchload/load_utils.py
@@ -66,7 +66,7 @@ def process_nodes(nodeprov, load_version, timestamp, nodes_out):
             })
         nodes_out.write(json.dumps(n) + '\n')
 
-def process_edge(edge, node_collection, load_version, timestamp):
+def process_edge(edge, load_version, timestamp):
     """
     Note that this funtion modifies the edge argument in place.
 
@@ -82,8 +82,6 @@ def process_edge(edge, node_collection, load_version, timestamp):
     to - the unique ID of the vertex where the edge terminates.
 
     edge - the edge as a dict.
-    node_collection - the name of the collection in which the nodes associated with the edge
-      reside. This is used to generate the _from and _to fields.
     load_version - the version of the load in which the edge appears. This is expected to be
       unique per load.
     timestamp - the timestamp at which the edge will begin to exist.
@@ -92,8 +90,8 @@ def process_edge(edge, node_collection, load_version, timestamp):
     """
     edge.update({
             '_key':             edge['id'] + '_' + load_version,
-            '_from':            node_collection + '/' + edge['from'] + '_' + load_version,
-            '_to':              node_collection + '/' + edge['to'] + '_' + load_version,
+            '_from':            edge['from'] + '_' + load_version,
+            '_to':              edge['to'] + '_' + load_version,
             'first_version':    load_version,
             'last_version':     load_version,
             'created':          timestamp,
@@ -101,7 +99,7 @@ def process_edge(edge, node_collection, load_version, timestamp):
         })
     return edge
 
-def process_edges(edgeprov, node_collection, load_version, timestamp, edges_out):
+def process_edges(edgeprov, load_version, timestamp, edges_out):
     """
     Process graph edges from a provider into a JSON load file for a batch time travelling load.
 
@@ -114,13 +112,11 @@ def process_edges(edgeprov, node_collection, load_version, timestamp, edges_out)
     to - the unique ID of the vertex where the edge terminates.
 
     edgeprov - the edge provider. This is an iterable that returns edges represented as dicts.
-    node_collection - the name of the collection in which the nodes associated with the edges
-      reside. This is used to generate the _from and _to fields.
     load_version - the version of the load in which the edges appear. This is expected to be
       unique per load.
     timestamp - the timestamp at which the edges will begin to exist.
     edges_out - a handle to the file where the edges will be written.
     """
     for e in edgeprov:
-        e = process_edge(e, node_collection, load_version, timestamp)
+        e = process_edge(e, load_version, timestamp)
         edges_out.write(json.dumps(e) + '\n')

--- a/relation_engine/ncbi/taxa/loaders/ncbi_taxa_bulk_loader.py
+++ b/relation_engine/ncbi/taxa/loaders/ncbi_taxa_bulk_loader.py
@@ -7,13 +7,11 @@
 # It should only be used for an initial load into the DB; delta loads for subsequent tax dumps
 # should be handled by the delta load script.
 
-# The script requires four inputs:
+# The script requires three inputs:
 # 1) The directory containing the unzipped taxa dump
-# 2) The name of the ADB collection in which the taxa nodes will be loaded
-#    (this is used to create the _from and _to fields in the edges)
-# 3) The version of the load - this is also expected to be unique between this base load and
+# 2) The version of the load - this is also expected to be unique between this base load and
 #    any delta loads.
-# 4) The time stamp for the load in unix epoch milliseconds - all nodes and edges will be marked
+# 3) The time stamp for the load in unix epoch milliseconds - all nodes and edges will be marked
 #    with this timestamp as the creation date.
 
 # The script creates two JSON files for uploading into Arango:   
@@ -43,10 +41,6 @@ def parse_args():
     parser.add_argument('--dir', required=True,
                         help='the directory containing the unzipped dump files')
     parser.add_argument(
-        '--node-collection',
-        required=True,
-        help='the name of the ArangoDB collection into which taxa nodes will be loaded')
-    parser.add_argument(
         '--load-version',
         required=True,
         help='the version of this load. This version will be added to a field in the nodes and ' +
@@ -74,7 +68,7 @@ def main():
 
     with open(nodes) as infile, open(edges_out, 'w') as edgef:
         edgeprov = NCBIEdgeProvider(infile)
-        process_edges(edgeprov, a.node_collection, a.load_version, a.load_timestamp, edgef)
+        process_edges(edgeprov, a.load_version, a.load_timestamp, edgef)
 
 if __name__  == '__main__':
     main()

--- a/relation_engine/ncbi/test/ncbi_taxa_bulk_loader_multiple_edges.py
+++ b/relation_engine/ncbi/test/ncbi_taxa_bulk_loader_multiple_edges.py
@@ -9,13 +9,11 @@
 # It should only be used for an initial load into the DB; delta loads for subsequent tax dumps
 # should be handled by the delta load script.
 
-# The script requires four inputs:
+# The script requires three inputs:
 # 1) The directory containing the unzipped taxa dump
-# 2) The name of the ADB collection in which the taxa nodes will be loaded
-#    (this is used to create the _from and _to fields in the edges)
-# 3) The version of the load - this is also expected to be unique between this base load and
+# 2) The version of the load - this is also expected to be unique between this base load and
 #    any delta loads.
-# 4) The time stamp for the load in unix epoch milliseconds - all nodes and edges will be marked
+# 3) The time stamp for the load in unix epoch milliseconds - all nodes and edges will be marked
 #    with this timestamp as the creation date.
 
 # The script creates two JSON files for uploading into Arango:   
@@ -44,10 +42,6 @@ def parse_args():
         description='Create ArangoDB bulk load files from an NCBI taxa dump.')
     parser.add_argument('--dir', required=True,
                         help='the directory containing the unzipped dump files')
-    parser.add_argument(
-        '--node-collection',
-        required=True,
-        help='the name of the ArangoDB collection into which taxa nodes will be loaded')
     parser.add_argument(
         '--load-version',
         required=True,
@@ -83,7 +77,7 @@ def main():
         }
         edgeprov = NCBIEdgeProvider(infile)
         for e in edgeprov:
-            e = process_edge(e, a.node_collection, a.load_version, a.load_timestamp)
+            e = process_edge(e, a.load_version, a.load_timestamp)
             fileno = int(e['id']) % 3 + 1
             files[fileno].write(json.dumps(e) + '\n')
 


### PR DESCRIPTION
That locks the load files to a particular node collection.

Instead, use `--from-collection-prefix` (and `-to-`...) `arangoimport`
arguments to specify node collection(s).