### PR TITLE
ENVO fixes, change ID separator

### DIFF
--- a/relation_engine/batchload/time_travelling_database.py
+++ b/relation_engine/batchload/time_travelling_database.py
@@ -8,6 +8,8 @@ more classes and methods can be added as needed.
 
 """
 
+# TODO CODE check id, from, and to for validity per https://www.arangodb.com/docs/stable/data-modeling-naming-conventions-document-keys.html
+
 from arango.exceptions import CursorEmptyError as _CursorEmptyError
 
 _INTERNAL_ARANGO_FIELDS = ['_rev']


### PR DESCRIPTION
All the valid OBOgraph files from releases in the ENVO GitHub repo now load.
That's only 3 files though.

Fixed issues:
1) ENVO has INDIVIDUAL type nodes. These can be treated the same way as
  CLASS nodes.
2) Since there's now 2 types of nodes that can appear in the graph, added a
  'type' field to the loaded nodes.
3) Some ENVO nodes don't have a 'type' field. Treat these as property nodes,
  which they all appear to be.
4) Some property nodes are missing labels. So far all of them have a
  single comment in meta/basicPropertyValues, so extract from there.
  Whether this is going to hold true for other graphs is unclear.

ID separator is now `:` vs `_`.